### PR TITLE
Patch#2 by ankit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     license='BSD',
     author='Gautam krishna R',
     author_email='r.gautamkrishna@gmail.com',
-    description='Stack overflow commnand line interface. SoCLI allows you to search and browse stack overfow from the terminal.',
+    description='Stack overflow commnand line interface. SoCLI allows you to search and browse stack overflow from the terminal.',
     long_description=longd
     )

--- a/socli/socli.py
+++ b/socli/socli.py
@@ -225,7 +225,7 @@ def socli_interactive(query):
                                 if cnt == 1:
                                     print_warning(" You cant go further back. You are on the first answer!")
                                     continue
-                                answer = (tmpsoup.find_all("div",class_="post-text")[cnt + 1].get_text())
+                                answer = (tmpsoup.find_all("div",class_="post-text")[cnt - 1].get_text())
                                 print_green("\n\nAnswer:\n")
                                 print("-------\n" + answer + "\n-------\n")
                                 cnt = cnt - 1


### PR DESCRIPTION
SoCLI was unable to show the previous answer by typing 'b' as input for interactive mode. This PR fixes the issue by decrementing the 'cnt' variable(which keep track of current post) which was originally incremented and caused this issue.