### PR TITLE
Add text 'No answers for this question ...' to avoid simple exit

### DIFF
--- a/socli/socli.py
+++ b/socli/socli.py
@@ -239,6 +239,8 @@ def get_question_stats_and_answer(url):
     soup = BeautifulSoup(res_page.text, 'html.parser')
     question_title, question_desc, question_stats = get_stats(soup)
     answers = [s.get_text() for s in soup.find_all("div", class_="post-text")][1:] # first post is question, discard it.
+    if len(answers) == 0:
+        answers.append('No answers for this question ...')
     return question_title, question_desc, question_stats, answers
 
 


### PR DESCRIPTION
When using `socli -iq` and selecting an unanswered question socli just quit without any messages.

This make several issues:

+ You can not read unanswered question
+ Socli will just exit if you select an empty question (disturbing, especially in interactive mode)
+ It looks like a big bug, but it's not.

I just added a pseudo-answer in `answers` list if this one is empty. Like that when selecting an empty question in interactive mode I'm able to read the question and just have a message 'No answers for this question...' which is explicit.