### PR TITLE
Caching pages has been implemented for interactive mode

### DIFF
--- a/socli/socli.py
+++ b/socli/socli.py
@@ -576,6 +576,7 @@ def socli_interactive(query):
 
         def __init__(self, questions):
             self.questions = questions
+            self.cachedQuestions = [None for _ in range(10)]
             widgets = [self.display_text(i, q) for i, q in enumerate(questions)]
             self.questions_box = ScrollableTextBox(widgets)
             header = UnicodeText(('less-important', 'Select a question below:\n'))
@@ -592,23 +593,22 @@ def socli_interactive(query):
         def keypress(self, size, key):
             if key in '0123456789':
                 question_url = self.questions[int(key)][2]
-                self.select_question(question_url)
+                self.select_question(question_url, int(key))
             elif key in {'down', 'up'}:
                 self.questions_box.keypress(size, key)
             else:
                 raise urwid.ExitMainLoop()
 
-        def select_question(self, url):
-            if not google_search:
-                url = sourl + url
-            question_title, question_desc, question_stats, answers = get_question_stats_and_answer(url)
-
-            if not answers:
-                print_warning("\n\nAnswer:\n\t No answer found for this question...")
-                sys.exit(0)
-
-            questions = QuestionPage((answers, question_title, question_desc, question_stats, url))
-            LOOP.widget = questions
+        def select_question(self, url, index):
+            if self.cachedQuestions[index] != None:
+                LOOP.widget = self.cachedQuestions[index]
+            else:
+                if not google_search:
+                    url = sourl + url
+                question_title, question_desc, question_stats, answers = get_question_stats_and_answer(url)
+                questions = QuestionPage((answers, question_title, question_desc, question_stats, url))
+                self.cachedQuestions[index] = questions
+                LOOP.widget = questions
 
     palette = [('answer', 'default', 'default'),
                ('title', 'light green, bold', 'default'),


### PR DESCRIPTION
This saves the QuestionPage object after visiting it once during interactive mode. This makes it so you do not issue multiple requests to Stack Overflow when you repeatedly select questions (max requests is equal to the number of questions displayed). This also tremendously speeds up displaying a question when visiting it again after the first time in the same session.