### PR TITLE
Use pydoc's pager module instead of normal print function #46

### DIFF
--- a/socli/socli.py
+++ b/socli/socli.py
@@ -331,7 +331,7 @@ def socli_interactive_windows(query):
     """
     try:
         
-	search_res = requests.get(soqurl + query)
+        search_res = requests.get(soqurl + query)
         soup = BeautifulSoup(search_res.text, 'html.parser')
         try:
             soup.find_all("div", class_="question-summary")[0]  # For explictly raising exception

--- a/socli/socli.py
+++ b/socli/socli.py
@@ -229,7 +229,6 @@ def helpman():
     if sys.stdout.isatty(): #if not running in a pipe
 	#pager(output_text) #launches $PAGER or less 
 	pipepager(output_text, cmd="less -r")
-	a = 1
     else:
 	print(output_text)    
 	


### PR DESCRIPTION
I have worked on the issue "Use pydoc's pager module instead of normal print function #46". I have used paged function instead of print wherever required. I suppose the pager functionality is not required in the interactive pages of questions and answers