### PR TITLE
Fixed URLError Exception Handling for both python3.x and python2.x

### DIFF
--- a/Portfile
+++ b/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# $Id$
+
+PortSystem			1.0
+PortGroup			github 1.0
+
+
+github.setup		gautamkrishnar socli 3.6
+github.tarball_from	releases
+
+
+categories			sysutils
+platforms			darwin
+license				BSD-3
+
+maintainers			gmail.com:r.gautamkrishna
+
+description			Stack Overflow CLI
+long_description	Stack Overflow command line written in python. \
+					Using SoCLI you can search and browse Stack Overflow \
+					without leaving the terminal
+
+
+homepage			http://www.github.com/gautamkrishnar/socli
+
+checksums			rmd160 f23f3bc03c722fe8eb45482bdb490b6f07971ae7
+					sha256 abf585ab347d8087870312f181c49f3b7f4a17084bd611adeadb03a6a063af41
+
+depends_lib			port:py-beautifulsoup4 \
+					port:py-colorama \
+					port:py-urwid \
+					port:py-requests \
+					lib:py-stackexchange
+use_zip				yes

--- a/socli/socli.py
+++ b/socli/socli.py
@@ -456,9 +456,15 @@ def socli_interactive(query):
             elif key in {'up', 'n', 'N'}:
                 self.answer_text.prev_ans()
             elif key in {'o', 'O'}:
-                import webbrowser
                 HEADER.event('browser', "Opening in your browser...")
-                webbrowser.open(self.url)
+                if sys.platform == 'darwin':
+                    import subprocess
+                    subprocess.Popen(['open', self.url])
+                elif sys.platform == 'win32':
+                    os.startfile(self.url)
+                else:
+                    import webbrowser
+                    webbrowser.open(self.url)
             elif key == 'left':
                 LOOP.widget = QUESTION_PAGE
 

--- a/socli/socli.py
+++ b/socli/socli.py
@@ -30,9 +30,8 @@ uas = []  # User agent list
 header = {}  # Request header
 google_search = True # Uses google search. Enabled by default.
 google_search_url = "https://www.google.com/search?q=site:stackoverflow.com+" #Google search query URL
-# Suppressing InsecureRequestWarning
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+# Suppressing InsecureRequestWarning and many others
+requests.packages.urllib3.disable_warnings()
 
 ### To support python 2:
 if sys.version < '3.0.0':
@@ -921,6 +920,8 @@ def fixGoogleURL(url):
     :param url:
     :return: Correctly formatted URL to be used in requests.get
     """
+    if "&sa=" in url:
+        url=url.split("&")[0]
     if "/url?q=" in url[0:7]:
         url = url[7:] #Removes the "/url?q=" prefix
 


### PR DESCRIPTION
When an error occurs during user info extracting, the function `userpage(userid)` does handle the exception `except urllib.error.URLError` when socli is installed on `python3.x` but doesn't handle it when socli is installed on `python 2.x`. So, I added two functions, one for Py2 and another one for Py3.