### PR TITLE
urlerror handling for both python2 and python3

### DIFF
--- a/socli/socli.py
+++ b/socli/socli.py
@@ -827,7 +827,12 @@ def userpage(userid):
     """
     global app_data
     import stackexchange
-
+    
+    try: 
+        from urllib.error import URLError
+    except ImportError:
+        from urllib2 import URLError
+        
     try:
         userid = int(userid)
     except ValueError as e:
@@ -863,7 +868,7 @@ def userpage(userid):
             print('Most curious about %s.' % userprofile.top_question_tags.fetch()[0].tag_name)
         else:
             print("You have 0 questions")
-    except urllib.error.URLError:
+    except URLError:
         print_fail("Please check your internet connectivity...")
         exit(1)
     except Exception as e:


### PR DESCRIPTION
If socli is installed on python 2, disconnect from internet and run the following command: 
`socli -u 1`. You'll get the following error message:
```
Traceback (most recent call last):
  File "socli.py", line 1221, in <module>
    main()
  File "socli.py", line 1194, in main
    userpage(user)
  File "socli.py", line 837, in userpage
    except urllib.error.URLError:
AttributeError: 'module' object has no attribute 'error'
```