### PR TITLE
Fixed a bug in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ try:
 except ImportError:
     from distutils.core import setup
 from codecs import open
-from sys import exit,version
+from sys import exit, version_info
 import sys
-if version < '1.0.0':
+if version_info[:3] < (2, 0, 0):
     print("Python 1 is not supported...")
     sys.exit(1)
 


### PR DESCRIPTION
`if version < '1.0.0':` is just comparing the strings, not the actual version numbers.

According to the [documentation](https://docs.python.org/3/library/sys.html#sys.version), we should rather use `version_info` to extract version information, so I made the following change:

`if version_info[:3] < (2, 0, 0):` # Since Requirements in the README says Python 2.0 or higher
