### PR TITLE
View documentation

### DIFF
--- a/socli/socli.py
+++ b/socli/socli.py
@@ -1152,6 +1152,7 @@ def auth_callback(response):
         print_fail("\n " + response['message']  + " \n")
 
 def doc_support():
+    from bs4 import BeautifulSoup as soup
     from urllib.request import urlopen
 
     def parseHTML(url):
@@ -1184,7 +1185,7 @@ def doc_support():
                 req_div = page_soup.find_all("div",{"id":div_id})
                 print(req_div[0].text)
                 return True
-        print("Invalid choice!")
+        print_warning("Invalid choice!")
         return False
 
 
@@ -1194,11 +1195,11 @@ def doc_support():
         try:
             version = int(input())
         except:
-            print("Invalid choice: Enter 1 or 2")
+            print_warning("Invalid choice: Enter 1 or 2")
             continue
         
         if version not in [1,2]:
-            print("Invalid choice, try again.")
+            print_warning("Invalid choice, try again.")
             continue
         else:
             if version == 1:
@@ -1233,10 +1234,10 @@ def doc_support():
                     flag = 1
                     break
                 else:
-                    print("Invalid choice.")
+                    print_warning("Invalid choice.")
         if flag == 0:
             flag = 1
-            break
+            sys.exit(0)
 
 def parseArguments(command):
     """

--- a/socli/socli.py
+++ b/socli/socli.py
@@ -469,6 +469,9 @@ def helpman():
               "\n    eg: " + make_warning(("socli --tag javascript,node.js --query foo bar")) + \
               ": Displays the search result of the query" + \
               " \"foo bar\" in Stack Overflow's javascript and node.js tags."  + '\n' + \
+        " " + bold("--doc") + \
+              " : Opens the documentation of Python2 and Python3 and let you navigate through " + \
+              "it." + '\n' + \
         " " + bold("--new or -n") + \
               " : Opens the Stack Overflow new questions page in your default browser. You can create a " + \
               "new question using it." + '\n' + \
@@ -1214,7 +1217,10 @@ def doc_support():
 
                 printNavList(index_items)
                 print("Enter:")
-                nav = input()
+                try:
+                    nav = input()
+                except KeyboardInterrupt:
+                    sys.exit(0)
                 if nav == "q":
                     flag = 0
                     break
@@ -1224,7 +1230,10 @@ def doc_support():
                 if not printDocData(nav, nav_url, index_items):
                     continue
                 print("q: quit\nl: documentation menu\nc: change python version")
-                choice = input()
+                try:
+                    choice = input()
+                except KeyboardInterrupt:
+                    sys.exit(0)
                 if choice == "q":
                     flag = 0
                     break

--- a/socli/socli.py
+++ b/socli/socli.py
@@ -1196,16 +1196,14 @@ def doc_support():
         print("1. Python 3.6\n2. Python 2.7")
         print("Enter your choice:")
         try:
-            version = int(input())
-        except:
-            print_warning("Invalid choice: Enter 1 or 2")
-            continue
-        
-        if version not in [1,2]:
+            version = input().rstrip()
+        except KeyboardInterrupt:
+            sys.exit(0)
+        if version not in ['1','2']:
             print_warning("Invalid choice, try again.")
             continue
         else:
-            if version == 1:
+            if version == '1':
                 placeholder = 3
             else:
                 placeholder = 2.7
@@ -1218,7 +1216,7 @@ def doc_support():
                 printNavList(index_items)
                 print("Enter:")
                 try:
-                    nav = input()
+                    nav = input().rstrip()
                 except KeyboardInterrupt:
                     sys.exit(0)
                 if nav == "q":
@@ -1231,7 +1229,7 @@ def doc_support():
                     continue
                 print("q: quit\nl: documentation menu\nc: change python version")
                 try:
-                    choice = input()
+                    choice = input().rstrip()
                 except KeyboardInterrupt:
                     sys.exit(0)
                 if choice == "q":

--- a/socli/socli.py
+++ b/socli/socli.py
@@ -1151,6 +1151,93 @@ def auth_callback(response):
     else:
         print_fail("\n " + response['message']  + " \n")
 
+def doc_support():
+    from urllib.request import urlopen
+
+    def parseHTML(url):
+        client = urlopen(url)
+        page_html = client.read()
+        client.close()
+        page_soup = soup(page_html,"html.parser")
+        return page_soup
+
+    def getNavList(page_soup):
+        index = page_soup.find_all("div", {"class":"toctree-wrapper"})
+        index_items = index[0].find_all("a", {"reference internal"})
+        return index_items
+
+    def printNavList(index_items):
+        for item in index_items:
+            print(item.text)
+
+    def printDocData(nav, nav_url, index_items):
+        nav = nav.rstrip('.')
+        k = len(nav)
+        for item in index_items:
+            if nav in item.text[:k]:
+                div_id = item['href'].split("#",1)
+                if len(div_id) == 2:
+                    div_id = div_id[1]
+                else:
+                    div_id = None
+                page_soup = parseHTML(nav_url + item['href'])
+                req_div = page_soup.find_all("div",{"id":div_id})
+                print(req_div[0].text)
+                return True
+        print("Invalid choice!")
+        return False
+
+
+    while(1):
+        print("1. Python 3.6\n2. Python 2.7")
+        print("Enter your choice:")
+        try:
+            version = int(input())
+        except:
+            print("Invalid choice: Enter 1 or 2")
+            continue
+        
+        if version not in [1,2]:
+            print("Invalid choice, try again.")
+            continue
+        else:
+            if version == 1:
+                placeholder = 3
+            else:
+                placeholder = 2.7
+            while 1:
+                nav_url = "https://docs.python.org/{}/reference/".format(placeholder)
+                my_url = "https://docs.python.org/{}/reference/index.html".format(placeholder)
+                page_soup = parseHTML(my_url)
+                index_items = getNavList(page_soup)
+
+                printNavList(index_items)
+                print("Enter:")
+                nav = input()
+                if nav == "q":
+                    flag = 0
+                    break
+                elif nav == "c":
+                    flag = 1
+                    break
+                if not printDocData(nav, nav_url, index_items):
+                    continue
+                print("q: quit\nl: documentation menu\nc: change python version")
+                choice = input()
+                if choice == "q":
+                    flag = 0
+                    break
+                elif choice == "l":
+                    continue
+                elif choice == "c":
+                    flag = 1
+                    break
+                else:
+                    print("Invalid choice.")
+        if flag == 0:
+            flag = 1
+            break
+
 def parseArguments(command):
     """
     Parses the command into arguments and flags
@@ -1200,6 +1287,7 @@ def parseArguments(command):
                                                   " \"foo bar\"'s most voted answer")
     parser.add_argument('--login', '-l', action='store_true', help="Prompt a user for email and password to login to StackOverflow.")
     parser.add_argument('--logout', action='store_true', help="Log a user out of StackOverflow")
+    parser.add_argument('--doc', action='store_true', help="View Python documentation")
 
     namespace = parser.parse_args(command)
     return namespace
@@ -1250,6 +1338,8 @@ def main():
         google_search = False
         tag = namespace.tag
         hastags()
+    if namespace.doc: # If --doc flag is present
+        doc_support()
     if namespace.res != None: #If --res flag is present
         questionNumber = namespace.res
         if namespace.query != [] or namespace.tag != None: #There must either be a tag or a query


### PR DESCRIPTION
This branch adds a feature of viewing the python(2 and 3) documentation from command-line. The documentation can be navigated through the command-line.
Usage: `socli --doc`
Further the user will be guided for the navigation.
In this feature documentation of other languages can be added. 
We are team codeVamps from RGSoC 2018.
Please review and do let us know if we can work on any other issues :)
Thank you!