### PR TITLE
No need to declare data_files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     name='socli',
     include_package_data=True,
     packages=["socli"],
-    data_files=[('socli', ['socli/user_agents.txt'])],
     entry_points = {"console_scripts": ['socli = socli.socli:main']},
     install_requires=['BeautifulSoup4','requests','colorama','Py-stackExchange', 'urwid'],
     requires=['BeautifulSoup4','requests','colorama','PyStackExchange', 'urwid'],


### PR DESCRIPTION
We're already declaring `include_package_data=True` and `recursive-include socli *` in MANIFEST.in. This ensures that the user_agent.txt file will be available in the package installation
path and thus will be accessible from the package's code.

Location resolved for data_files is unreliable, so let's just get rid of
it since we don't need it.

This fixes https://github.com/gautamkrishnar/socli/issues/148.