### PR TITLE
Issue #163 - Fixed Google Search not returning results

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 colorama
 Py-StackExchange
 urwid
+requests_html


### PR DESCRIPTION
Used ```requests_html``` instead of ```requests``` to fetch JavaScript rendered Google results webpage.

Tested on Ubuntu 18.04.

** For a normal Google Search query**

![socli_google_search](https://user-images.githubusercontent.com/8661410/73389681-b4c09a80-42fa-11ea-8f0c-84dafa9e365d.png)

** For an interactive Google Search query**

![socli_interactive](https://user-images.githubusercontent.com/8661410/73389682-b4c09a80-42fa-11ea-878c-f3d8d1ff1ade.png)

---
**Note**
> ```requests_html``` requires **Python 3.6** or above. If this PR looks good, and can be merged, I will go ahead and modify the README and other files to reflect the use of Python 3.6.