### PR TITLE
attempted bugfix for issue 179

### DIFF
--- a/socli/search.py
+++ b/socli/search.py
@@ -134,9 +134,7 @@ def get_stats(soup):
     question_title = (soup.find_all("a", class_="question-hyperlink")[0].get_text())
     question_stats = (soup.find_all("div", class_="js-vote-count")[0].get_text())
     try:
-        question_stats = "Votes " + question_stats + " | " + (((soup.find_all("div", class_="module question-stats")[0]
-                                                                .get_text()).replace("\n", " ")).replace("     ",
-                                                                                                         " | "))
+        question_stats = "Votes " + question_stats + " | asked " + (soup.find("time").get_text()) + " | active " + (soup.find("a", href="?lastactivity").get_text()) + " | viewed " + (soup.find("div", class_="grid--cell ws-nowrap mb8").get_text().split("\r"))[1].strip()
     except IndexError:
         question_stats = "Could not load statistics."
     question_desc = (soup.find_all("div", class_="post-text")[0])


### PR DESCRIPTION
## Context
This is in reference to issue #179.

## What it solves
I looked through a random sample Q/A page of stackoverflow. Turns out they don't have the previous structure, as @hedythedev pointed out in the comments.
To solve this, I had to refactor the entire line of code that was fetching the stats.
The code now relies on different tags each for the view, vote counts and the post, last activity dates.

**note**: about the view count, I'm having to rely on a css tag. This is because there is only one part of the page that shows the view counter, and I don't think we have any option besides resorting to that.

I'm half confident that stackoverflow might change that class again, soon, and might continue to do so. If we cannot find a better solution, I would suggest that we remove the view counter entirely.
I'm very new to contributing to open source, I would like to hear others' take on this.