### PR TITLE
Issue179

### DIFF
--- a/socli/search.py
+++ b/socli/search.py
@@ -134,9 +134,25 @@ def get_stats(soup):
     question_title = (soup.find_all("a", class_="question-hyperlink")[0].get_text())
     question_stats = (soup.find_all("div", class_="js-vote-count")[0].get_text())
     try:
-        question_stats = "Votes " + question_stats + " | " + (((soup.find_all("div", class_="module question-stats")[0]
-                                                                .get_text()).replace("\n", " ")).replace("     ",
-                                                                                                         " | "))
+        # question_stats = "Votes " + question_stats + " | " + (((soup.find_all("div", class_="module question-stats")[0]
+        #                                                         .get_text()).replace("\n", " ")).replace("     ",
+        #                                                                                                  " | "))
+        # active_info = soup.find("a", href="?lastactivity").get_text()
+        # asked_info = soup.find("time").get_text()
+        # Asked_branch = soup.find("time")
+        # asked_info = Asked_branch.get_text()
+        # Active_branch = Asked_branch.parent.findNext('div')
+        # Viewed_branch = Active_branch.parent.findNext('div')
+
+        # viewed_info = (soup.find("div", class_="grid--cell ws-nowrap mb8").get_text().split("\r"))[1].strip()
+        # viewed = (soup.find(text="Viewed"))
+        # viewed_class = viewed.parent
+        # viewed_info = viewed_class.get_text().split("\r")
+        # viewed_info = viewed
+        asked_info = soup.find("time").parent.get_text()
+        active_info = soup.find("time").parent.findNext('div').get_text()
+        viewed_info = soup.find("time").parent.findNext('div').findNext('div').get_text()#.findNext('class').get_text()
+        question_stats = "Votes " + question_stats + " | " + asked_info + " | " + active_info + " | " + viewed_info
     except IndexError:
         question_stats = "Could not load statistics."
     question_desc = (soup.find_all("div", class_="post-text")[0])

--- a/socli/search.py
+++ b/socli/search.py
@@ -138,7 +138,7 @@ def get_stats(soup):
         active_info = soup.find("time").parent.findNext('div').get_text()
         viewed_info = soup.find("time").parent.findNext('div').findNext('div').get_text()
         question_stats = "Votes " + question_stats + " | " + asked_info + " | " + active_info + " | " + viewed_info
-    except IndexError:
+    except:
         question_stats = "Could not load statistics."
     question_desc = (soup.find_all("div", class_="post-text")[0])
     add_urls(question_desc)

--- a/socli/search.py
+++ b/socli/search.py
@@ -134,24 +134,9 @@ def get_stats(soup):
     question_title = (soup.find_all("a", class_="question-hyperlink")[0].get_text())
     question_stats = (soup.find_all("div", class_="js-vote-count")[0].get_text())
     try:
-        # question_stats = "Votes " + question_stats + " | " + (((soup.find_all("div", class_="module question-stats")[0]
-        #                                                         .get_text()).replace("\n", " ")).replace("     ",
-        #                                                                                                  " | "))
-        # active_info = soup.find("a", href="?lastactivity").get_text()
-        # asked_info = soup.find("time").get_text()
-        # Asked_branch = soup.find("time")
-        # asked_info = Asked_branch.get_text()
-        # Active_branch = Asked_branch.parent.findNext('div')
-        # Viewed_branch = Active_branch.parent.findNext('div')
-
-        # viewed_info = (soup.find("div", class_="grid--cell ws-nowrap mb8").get_text().split("\r"))[1].strip()
-        # viewed = (soup.find(text="Viewed"))
-        # viewed_class = viewed.parent
-        # viewed_info = viewed_class.get_text().split("\r")
-        # viewed_info = viewed
         asked_info = soup.find("time").parent.get_text()
         active_info = soup.find("time").parent.findNext('div').get_text()
-        viewed_info = soup.find("time").parent.findNext('div').findNext('div').get_text()#.findNext('class').get_text()
+        viewed_info = soup.find("time").parent.findNext('div').findNext('div').get_text()
         question_stats = "Votes " + question_stats + " | " + asked_info + " | " + active_info + " | " + viewed_info
     except IndexError:
         question_stats = "Could not load statistics."


### PR DESCRIPTION
This is a solution on the issue #179 and maybe an improvement on #180 . The initial solution provided by @therajdeepbiswas was great, but it heavily relies on the css tag. The changes I've made ensures that we first locate the information by finding the "time" tag, and then we traverse back to its parent to find all the necessary information of asked_info, active_info and viewed_info. The code is relatively straight forward to understand, as all those three information can be achieved by access the 'div' and we can even use the words from StackOverflow directly so that we don't need to hand code things like 'asked ...', 'active ...' and 'viewed ...' 

This is my very first attempt on contributing on an open source project, and I've found socli a great project to work on. Please note that I forked it when it was version 4.0 I believe, but search.py is the only file I've changed. Please review the pull request and let me know if this is a good solution that can be merged into the master branch or if you have any other feedback. Thank you.

![Screen Shot 2020-06-25 at 8 09 36 AM](https://user-images.githubusercontent.com/55098065/85717173-399dbd80-b6bb-11ea-8f17-fbb59d727a4d.png)

