### PR TITLE
improve google search url to get better results

### DIFF
--- a/socli/search.py
+++ b/socli/search.py
@@ -21,7 +21,7 @@ google_search = True
 so_url = "http://stackoverflow.com"  # Site URL
 so_qurl = "http://stackoverflow.com/search?q="  # Query URL
 so_burl = "https://stackoverflow.com/?tab="  # Assuming browse URL
-google_search_url = "https://www.google.com/search?q=site:www.stackoverflow.com+"  # Google search query URL
+google_search_url = "https://www.google.com/search?q=site:stackoverflow.com+"  # Google search query URL
 
 
 def get_questions_for_query(query, count=10):


### PR DESCRIPTION
When I was using socli to get answers to my problems, I was surprised to see it give somehow irrelevant results, so I debugged it and found that using the query `site:stackoverflow.com` was better than `site:www.stackoverflow.com`.

Here's an example:

```
python -m socli -iq how to turn a string into a int in python
```

### before
<img width="851" alt="before" src="https://user-images.githubusercontent.com/50042066/93863776-86af2100-fcf6-11ea-8efc-4b01fac706dc.png">

### after
<img width="955" alt="after" src="https://user-images.githubusercontent.com/50042066/93863825-9a5a8780-fcf6-11ea-8b17-4078571bc689.png">
