### PR TITLE
argcomplete

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ colorama~=0.4.3
 py-stackexchange==2.2.7
 sentry-sdk==0.18.0
 urwid~=2.1.1
+argcomplete

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=["socli"],
     entry_points={"console_scripts": ['socli = socli.sentry:main']},
     python_requires='>=3.5.0',
-    install_requires=['BeautifulSoup4', 'requests', 'colorama', 'Py-stackExchange', 'sentry_sdk', 'urwid'],
+    install_requires=['BeautifulSoup4', 'requests', 'colorama', 'Py-stackExchange', 'sentry_sdk', 'urwid', 'argcomplete'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     requires=['BeautifulSoup4', 'requests', 'colorama', 'PyStackExchange', 'sentry_sdk', 'urwid'],

--- a/socli/parser.py
+++ b/socli/parser.py
@@ -1,7 +1,7 @@
 """
 Contains all functions used for parsing the command line args
 """
-import argparse
+import argparse,argcomplete
 import textwrap
 
 
@@ -64,6 +64,7 @@ def parse_arguments(command):
     parser.add_argument('--json', '-j', action='store_true', help='Write output to stdout as json')
 
     parser.add_argument('--version' , '-v', action='store_true', help='Prints the current version of socli')
-
+    
+    argcomplete.autocomplete(parser)
     namespace = parser.parse_args(command)
     return namespace


### PR DESCRIPTION
added argcomplete library to provide argument complete function #234  , but here it still requires to manually put [ eval "$(register-python-argcomplete socli)"]  at the end of .bashrc file.
![socli](https://user-images.githubusercontent.com/53306550/104635425-e1b2bc80-56c7-11eb-8d71-d4d3e054768e.gif)

