### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ socli -t javascript,node.js -q window.open
 See the complete list of tags [here](http://stackoverflow.com/tags).
 
 ##### User Profile Browsing
-Just use the command below to set your [user ID]( http://meta.stackexchange.com/a/111130) in socli. When you execute the command next time, it will automaticially fetch the data.
+Just use the command below to set your [user ID]( http://meta.stackexchange.com/a/111130) in socli. When you execute the command next time, it will automatically fetch the data.
 ```sh
 socli -u
 ```

--- a/socli/search.py
+++ b/socli/search.py
@@ -113,7 +113,7 @@ def get_questions_for_query_google(query, count=10):
 def get_comments(soup):
     """
     :param soup
-    extacts comments on the answers
+    extracts comments on the answers
     """
     comments_list = []
     raw_comments_list = soup.find_all("ul", class_="js-comments-list")
@@ -205,7 +205,7 @@ def socli_interactive_windows(query):
         captcha_check(search_res.url)
         soup = BeautifulSoup(search_res.text, 'html.parser')
         try:
-            soup.find_all("div", class_="question-summary")[0]  # For explictly raising exception
+            soup.find_all("div", class_="question-summary")[0]  # For explicitly raising exception
             tmp = (soup.find_all("div", class_="question-summary"))
             tmp1 = (soup.find_all("div", class_="excerpt"))
             i = 0


### PR DESCRIPTION
There are small typos in:
- README.md
- socli/search.py

Fixes:
- Should read `extracts` rather than `extacts`.
- Should read `explicitly` rather than `explictly`.
- Should read `automatically` rather than `automaticially`.

Closes: #268 