### PR TITLE
search.py - fixed instant answer bug 

### DIFF
--- a/socli/search.py
+++ b/socli/search.py
@@ -86,8 +86,8 @@ def get_questions_for_query_google(query, count=10):
             question_title = result.find("h3").get_text().replace(' - Stack Overflow', '')
             # Instant answers will raise IndexError here
             question_desc = result.find("div", recursive=False).find("div", recursive=False) \
-                .findAll("div", recursive=False)[1].findAll("div", recursive=False)[1] \
-                .getText()
+                .find_all("div", recursive=False)[0].find_all("div", recursive=False)[0] \
+                .get_text()
 
             question_url = result.find("a").get("href")  # Retrieves the Stack Overflow link
             question_url = fix_google_url(question_url.lower())


### PR DESCRIPTION
When using socli to search with Google, No results found always returned instead of the actual results. After troubleshooting, I tracked down the bug at line 88 in search.py where it tries to throw an IndexError on purpose when Instant Answers appear.

This should solve issu #287 